### PR TITLE
Fix Improper Handling of Case Sensitivity dev server option 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ devDependencies:
     specifier: ^5.2.2
     version: 5.3.3
   vite:
-    specifier: ^5.0.8
-    version: 5.0.10
+    specifier: ^5.0.12
+    version: 5.0.12
   vite-plugin-html-inject:
     specifier: ^1.1.2
     version: 1.1.2
@@ -506,8 +506,8 @@ packages:
     resolution: {integrity: sha512-4DWANEcAw73H5JLWTAI4EvXdSyoGqGq/Is9fTRjpF+SJLor58LNdqB+YYnK3FOLwx6LMTAn4z1hkiRyc52lYLg==}
     dev: true
 
-  /vite@5.0.10:
-    resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
+  /vite@5.0.12:
+    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION

## Summary
The project `chromeos/iwa-sink` has used Vite dev server option server.fs.deny can be bypassed on case-insensitive file systems using case-augmented versions of filenames.  There issue Improper Handling of Case Sensitivity dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem

**Patches**
Fixed in vite@5.0.12, vite@4.5.2, vite@3.2.8, vite@2.9.17

## Proof of concept：
1 . Created vanilla Vite project using npm create `vite@latest` on a Standard Azure hosted Windows 10 instance.
 * `npm run dev -- --host 0.0.0.0`
 * Publicly accessible for the time being here: http://20.12.242.81:5173/

2. Created dummy secret files, e.g. `custom.secret` and `production.pem`
3. Populated `vite.config.js` with

```js
export default { server: { fs: { deny: ['.env', '.env.*', '*.{crt,pem}', 'custom.secret'] } } }
```

## Reproduction
 * `curl -s http://20.12.242.81:5173/@fs//`
  * Descriptive error page reveals absolute filesystem path to project root
 * `curl -s http://20.12.242.81:5173/@fs/C:/Users/darbonzo/Desktop/vite-project/vite.config.js`
  * Discoverable configuration file reveals locations of secrets
 * `curl -s http://20.12.242.81:5173/@fs/C:/Users/darbonzo/Desktop/vite-project/custom.sEcReT`
  * Secrets are directly accessible using case-augmented version of filename

|    PoCs    |
| ------------- |
|![Index](https://user-images.githubusercontent.com/907968/298020728-3a8d3c06-fcfd-4009-9182-e842f66a6ea5.png)|


## Impact
**Who**
 * Users with exposed dev servers on environments with case-insensitive filesystems

**What**
 * Files protected by `server.fs.deny` are both discoverable, and  accessible
CWE-178 
CWE-200 
CWE-284