### PR TITLE
Support Ecdsa P-256 SHA-256 signing scheme in IWA-Sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ After downloading this repository and installing its dependencies (`pnpm i`), yo
 
 To create a bundled application, you'll also need to generate an encrypted signing key. To do so, run the following:
 
-1. Generate an unencrypted Ed25519 key inside the `certs` directory you previously made running the following inside it: `openssl genpkey -algorithm Ed25519 -out ed25519key.pem`
-2. Encrypt the generated key by then running `openssl pkcs8 -in ed25519key.pem -topk8 -out encrypted_ed25519key.pem`, then delete the unencrypted key. You can now [build the app](#running-and-updating).
-3. (optional) Create a `.env` file in the root of the project, and add `KEY_PASSPHRASE=`, setting it equal to your passphrase. If you don't do this, you'll need to enter your passphrase every time you go to build the project. You can also add a `KEY=` line in that file, setting it equal to the contents of `encrypted_ed25519key.pem`. This is to mimic a CI/CD environment; see `vite.config.js` for how this gets handled.
+1. Generate an unencrypted Ed25519 or Ecdsa P-256 key by running **one of the two** following commands inside the `certs` directory that you previously made:
+
+- `openssl genpkey -algorithm Ed25519 -out private_key.pem` (for Ed25519)
+- `openssl ecparam -name prime256v1 -genkey -noout -out private_key.pem` (for Ecdsa P-256)
+
+2. Encrypt the generated key by then running `openssl pkcs8 -in private_key.pem -topk8 -out encrypted_private_key.pem`, then delete the unencrypted key. You can now [build the app](#running-and-updating).
+3. (optional) Create a `.env` file in the root of the project, and add `KEY_PASSPHRASE=`, setting it equal to your passphrase. If you don't do this, you'll need to enter your passphrase every time you go to build the project. You can also add a `KEY=` line in that file, setting it equal to the contents of `encrypted_private_key.pem`. This is to mimic a CI/CD environment; see `vite.config.js` for how this gets handled.
 4. Once built, you can go to `chrome://web-app-internals` to install the bundle.
 
 ---

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "devDependencies": {
     "dotenv": "^16.4.2",
     "prettier": "^3.2.5",
-    "rollup-plugin-webbundle": "^0.1.3",
+    "rollup-plugin-webbundle": "^0.2.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.13",
     "vite-plugin-html-inject": "^1.1.2",
-    "wbn-sign": "^0.1.2"
+    "wbn-sign": "^0.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 devDependencies:
   dotenv:
     specifier: ^16.4.2
@@ -12,8 +8,8 @@ devDependencies:
     specifier: ^3.2.5
     version: 3.2.5
   rollup-plugin-webbundle:
-    specifier: ^0.1.3
-    version: 0.1.3(rollup@3.29.4)
+    specifier: ^0.2.0
+    version: 0.2.0(rollup@3.29.4)
   typescript:
     specifier: ^5.2.2
     version: 5.3.3
@@ -24,8 +20,8 @@ devDependencies:
     specifier: ^1.1.2
     version: 1.1.2
   wbn-sign:
-    specifier: ^0.1.2
-    version: 0.1.2
+    specifier: ^0.2.0
+    version: 0.2.0
 
 packages:
 
@@ -357,6 +353,11 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+    dev: true
+
   /dotenv@16.4.2:
     resolution: {integrity: sha512-rZSSFxke7d9nYQ5NeMIwp5PP+f8wXgKNljpOb7KtH6SKW1cEqcXAz9VSJYVLKe7Jhup/gUYOkaeSVyK8GJ+nBg==}
     engines: {node: '>=12'}
@@ -444,16 +445,16 @@ packages:
       mute-stream: 1.0.0
     dev: true
 
-  /rollup-plugin-webbundle@0.1.3(rollup@3.29.4):
-    resolution: {integrity: sha512-qNsmGV6oPfLVZMVxK/5ZH+QJODCcAhmWjdkXOYFGRVvw/i4VmTFN0vnOKEukLdaYO9UTUbEM20rfzvzLn5CoKA==}
-    engines: {node: '>= 14.0.0'}
+  /rollup-plugin-webbundle@0.2.0(rollup@3.29.4):
+    resolution: {integrity: sha512-cEseq7kqLpx6MMUkzvRIk1btO635hPXHH0tjvyIODaUhxwe2RZaSGCJhKc4U9G7HvflrwUttGiHtyullO3ZOCQ==}
+    engines: {node: '>= 16.0.0'}
     peerDependencies:
       rollup: '>=1.21.0 <4.0.0'
     dependencies:
       mime: 2.6.0
       rollup: 3.29.4
       wbn: 0.0.9
-      wbn-sign: 0.1.1
+      wbn-sign: 0.2.0
       zod: 3.22.4
     dev: true
 
@@ -541,25 +542,14 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /wbn-sign@0.1.1:
-    resolution: {integrity: sha512-yra2bZvC4PuKISqyDvHs3/aUClmf7txb+ttJLshs8auA6+ZPr9F+ejmqduNweQDob2+YaL1hm8FWiVlsVRK9Ag==}
-    engines: {node: '>= 14.0.0', npm: '>= 8.0.0'}
+  /wbn-sign@0.2.0:
+    resolution: {integrity: sha512-tk1a9Ofb73A6SnvWAT38qxuAfVr7FF7gIseUVfHQeMJeB+aXv5fUuSXU5mbxgUPS1NFEdf9SgrXWYHBzDgX57Q==}
+    engines: {node: '>= 16.0.0', npm: '>= 8.0.0'}
     hasBin: true
     dependencies:
       base32-encode: 2.0.0
       cborg: 1.10.2
-      commander: 4.1.1
-      read: 2.1.0
-    dev: true
-
-  /wbn-sign@0.1.2:
-    resolution: {integrity: sha512-1wsbJQ/FF1HPn88p6jP4hRVcW3yrjvD4yv1UPLam5TSR4ek8NQbGTNr6w0jhgFqRDenr1cV9e9Qmr6nLNKzfgA==}
-    engines: {node: '>= 14.0.0', npm: '>= 8.0.0'}
-    hasBin: true
-    dependencies:
-      base32-encode: 2.0.0
-      cborg: 1.10.2
-      commander: 4.1.1
+      commander: 7.2.0
       read: 2.1.0
     dev: true
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,8 +29,11 @@ const plugins = [injectHTML()];
 if (process.env.NODE_ENV === 'production') {
   // Get the key and decrypt it to sign the web bundle
   const key = wbnSign.parsePemKey(
-    process.env.KEY || fs.readFileSync('./certs/encrypted_ed25519key.pem'),
-    process.env.KEY_PASSPHRASE || (await wbnSign.readPassphrase()),
+    process.env.KEY || fs.readFileSync('./certs/encrypted_private_key.pem'),
+    process.env.KEY_PASSPHRASE ||
+    (await wbnSign.readPassphrase(
+        /*description=*/ './certs/encrypted_private_key.pem',
+    )),
   );
 
   // Add the wbn bundle only during a production build


### PR DESCRIPTION
This PR adds support for the *Ecdsa P-256 SHA-256* signing scheme and bumps `wbn-sign` / `rollup-plugin-webbundle` to `0.2.0`.