### PR TITLE
Fix controlled frame permission policy in the manifest.

### DIFF
--- a/public/.well-known/manifest.webmanifest
+++ b/public/.well-known/manifest.webmanifest
@@ -20,7 +20,7 @@
   "permissions_policy": {
     "cross-origin-isolated": ["self"],
     "direct-sockets": ["self"],
-    "controlledframe": ["self"],
+    "controlled-frame": ["self"],
     "window-management": ["self"],
     "all-screens-capture": ["self"]
   }


### PR DESCRIPTION
There's a typo in the permission policy name.