### PR TITLE
Bind TCPServerSocket only on localhost instead of all interfaces

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@
 
 import { collectConnections, readStream, writeStream } from './streams';
 
-const server = new TCPServerSocket('::');
+const server = new TCPServerSocket('::1');
 let address: string;
 let port: number;
 let connections = 0;


### PR DESCRIPTION
`::` is too broad -- `::1` will do just fine.